### PR TITLE
Add @claude mention trigger and bun-path input

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -21,6 +21,11 @@ on:
         description: "Tools allowed for Claude to use"
         required: false
         default: "Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
+      bun-path:
+        type: string
+        description: "Path to pre-installed Bun runtime (leave blank to let Claude install Bun)"
+        required: false
+        default: /home/runner/.bun/bin/bun
     secrets:
       CLAUDE_TOKEN:
         description: "Claude Code OAuth token"
@@ -47,6 +52,7 @@ jobs:
           ANTHROPIC_MODEL: ${{ inputs.anthropic-model }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_TOKEN }}
+          path_to_bun_executable: ${{ inputs.bun-path }}
           use_sticky_comment: true
           track_progress: true
           plugin_marketplaces: |

--- a/docs/claude-pr-review.md
+++ b/docs/claude-pr-review.md
@@ -34,6 +34,12 @@ This depends on the following actions:
 
 **Default** `Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob`
 
+### `bun-path`
+
+**Optional** Path to pre-installed Bun runtime (leave blank to let Claude install Bun)
+
+**Default** `/home/runner/.bun/bin/bun`
+
 ## Secrets
 
 ### `CLAUDE_TOKEN`
@@ -48,13 +54,22 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
 
 jobs:
   review:
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude'))
     uses: oncoursesystems/workflows/.github/workflows/claude-pr-review.yml@main
     secrets:
       CLAUDE_TOKEN: ${{ secrets.CLAUDE_TOKEN }}
 ```
+
+This triggers on PR events or when someone mentions `@claude` in a PR comment.
 
 ### With Custom Options
 

--- a/examples/claude-pr-review.yml
+++ b/examples/claude-pr-review.yml
@@ -3,9 +3,16 @@ name: claude-pr-review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
 
 jobs:
   review:
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude'))
     uses: oncoursesystems/workflows/.github/workflows/claude-pr-review.yml@main
     secrets:
       CLAUDE_TOKEN: ${{ secrets.CLAUDE_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `@claude` mention trigger to example workflow - reviews can be requested by commenting on a PR
- Adds `bun-path` input to specify pre-installed Bun runtime location
- Updates documentation with new input and trigger usage

## Test plan
- [ ] Verify workflow triggers on PR open/sync/reopen
- [ ] Verify workflow triggers when commenting `@claude` on a PR
- [ ] Confirm bun-path defaults work on k8s-linux runners