### PR TITLE
fix(docker-build): upgrade all actions to latest versions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: ⚙️  Setup Docker BuildX
         id: buildx
@@ -98,7 +98,7 @@ jobs:
           flavor: ${{ inputs.flavor-rules }}
 
       - name: 🚀 Docker Build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: ${{ inputs.platforms }}
           context: ${{ inputs.context || '.' }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -71,11 +71,11 @@ jobs:
 
       - name: ⚙️  Setup Docker BuildX
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: 🏦 Login to registry
         if: inputs.registry == 'ghcr.io'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ inputs.registry }}
           username: ${{ github.actor }}
@@ -83,7 +83,7 @@ jobs:
 
       - name: 🏦 Login to registry
         if: inputs.registry != 'ghcr.io'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ inputs.registry }}
           username: ${{ secrets.docker-username }}
@@ -91,14 +91,14 @@ jobs:
 
       - name: 🏷️ Extract metadata (tags, labels)
         id: metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ inputs.registry }}/${{ inputs.image-name }}
           tags: ${{ inputs.tag-rules }}
           flavor: ${{ inputs.flavor-rules }}
 
       - name: 🚀 Docker Build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: ${{ inputs.platforms }}
           context: ${{ inputs.context || '.' }}
@@ -106,8 +106,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           push: ${{ inputs.push }}
           tags: ${{ steps.metadata.outputs.tags }}
-          labels: $${{ steps.metadata.outputs.labels }}
-          provenance: false
+          labels: ${{ steps.metadata.outputs.labels }}
           build-args: |
             APP_VERSION=${{ steps.metadata.outputs.version }}
           # use github cache API for faster builds:


### PR DESCRIPTION
## Summary
- Upgrade all actions to latest major versions:
  - `actions/checkout` v4 → v6
  - `docker/setup-buildx-action` v3 → v4
  - `docker/login-action` v3 → v4
  - `docker/metadata-action` v5 → v6
  - `docker/build-push-action` v5 → v7
- Remove `provenance: false` workaround — the GHCR 403 was caused by package ownership (created by archived repo), not provenance attestation
- Fix double-dollar typo on `labels` that was preventing OCI labels from being applied to images
- Resolves Node.js 20 deprecation warning — new action versions run on Node.js 24

## Test plan
- [ ] Merge this PR
- [ ] Trigger a docker build from any consuming repo and verify it completes successfully
- [ ] Verify image labels are now correctly applied (check with `docker inspect` or GHCR UI)