### PR TITLE
Add dotnet-locked-mode restore to web-ci workflow

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -31,6 +31,10 @@ on:
         type: string
         required: false
         default: .
+      dotnet-locked-mode:
+        type: boolean
+        required: false
+        default: false
 
 env:
   DOTNET_INSTALL_DIR: "./.dotnet" # Needed otherwise dotnet setup will fail due to permissions on the k8s runner
@@ -103,10 +107,15 @@ jobs:
           cache: true
           cache-dependency-path: "**/*.csproj"
 
+      - name: 📦 Dotnet restore (locked mode)
+        if: steps.test.outputs.files_exists == 'true' && inputs.dotnet-locked-mode
+        working-directory: ${{ inputs.dotnet-project-path }}
+        run: dotnet restore --locked-mode
+
       - name: 🚀 Dotnet build
         if: steps.test.outputs.files_exists == 'true'
         working-directory: ${{ inputs.dotnet-project-path }}
-        run: dotnet build --nologo --configuration Release
+        run: dotnet build --nologo --configuration Release ${{ inputs.dotnet-locked-mode && '--no-restore' || '' }}
 
   build-dotnet-framework:
     runs-on: ${{ inputs.runs-on }}


### PR DESCRIPTION
## Summary
- Adds an opt-in `dotnet-locked-mode` boolean input (default: `false`) to the `web-ci.yml` reusable workflow
- When enabled, inserts a `dotnet restore --locked-mode` step before the build, which fails if `packages.lock.json` is stale or missing
- The build step uses `--no-restore` when locked mode is on to skip redundant restore
- Fully backward compatible — existing callers are unaffected since the default is `false`

## Test plan
- [ ] Verify existing repos that don't pass `dotnet-locked-mode` still build normally
- [ ] Verify oncourse-connect CI passes with `dotnet-locked-mode: true` after merging this