### PR TITLE
fix: standardize all workflows to k8s-linux runner

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       runs-on:
         type: string
-        default: self-hosted
+        default: k8s-linux
       version:
         description: Use to override the default generated version
         required: false

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -32,7 +32,7 @@ on:
       runs-on:
         description: Defines the type of machine to run the workflow on
         type: string
-        default: self-hosted
+        default: k8s-linux
       push:
         description: Enables pushing of the image to the container registry
         type: boolean

--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       runs-on:
         type: string
-        default: self-hosted
+        default: k8s-linux
       package-name:
         type: string
         default: ${{ github.event.repository.name }}

--- a/.github/workflows/pr-preview-notify.yml
+++ b/.github/workflows/pr-preview-notify.yml
@@ -15,6 +15,9 @@ on:
       argocd-app-name:
         required: true
         type: string
+      runs-on:
+        type: string
+        default: k8s-linux
     secrets:
       GH_APP_ID:
         required: true
@@ -27,7 +30,7 @@ on:
 
 jobs:
   wait-and-notify:
-    runs-on: k8s-linux
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Generate GitHub App token
         id: app-token

--- a/.github/workflows/web-cd.yml
+++ b/.github/workflows/web-cd.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       runs-on:
         type: string
-        default: self-hosted
+        default: k8s-linux
 
 jobs:
   docker-publish:

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       runs-on:
         type: string
-        default: self-hosted
+        default: k8s-linux
       sparse-checkout:
         type: string
         required: false

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -6,6 +6,9 @@ on:
       runs-on:
         type: string
         default: k8s-linux
+      runs-on-windows:
+        type: string
+        default: self-hosted
       sparse-checkout:
         type: string
         required: false
@@ -109,7 +112,7 @@ jobs:
         run: dotnet build --nologo --configuration Release
 
   build-dotnet-framework:
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ inputs.runs-on-windows }}
     steps:
       - name: ⬇️ Checkout repository
         uses: actions/checkout@v4

--- a/docs/create-release.md
+++ b/docs/create-release.md
@@ -14,7 +14,7 @@ This depends on the following actions:
 
 **Optional** The type of runner to use for the job
 
-**Default** `self-hosted`
+**Default** `k8s-linux`
 
 ### `version`
 

--- a/docs/docker-build.md
+++ b/docs/docker-build.md
@@ -32,7 +32,7 @@ This depends on the following actions:
 
 **Optional** Defines the type of machine to run the workflow on
 
-**Default** `self-hosted`
+**Default** `k8s-linux`
 
 ### `push`
 

--- a/docs/docker-cleanup.md
+++ b/docs/docker-cleanup.md
@@ -13,7 +13,7 @@ This depends on the following actions:
 
 **Optional** The type of runner to use for the job
 
-**Default** `self-hosted`
+**Default** `k8s-linux`
 
 ### `package-name`
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -279,7 +279,7 @@ jobs:
   e2e:
     uses: oncoursesystems/workflows/.github/workflows/e2e-testing.yml@main
     with:
-      runs-on: ubuntu-latest
+      runs-on: k8s-linux
       test-dir: ./e2e-tests
       base-url: https://preview-${{ github.event.pull_request.number }}.example.com
       tags: ${{ github.event.inputs.tags || 'smoke' }}

--- a/docs/pr-preview.md
+++ b/docs/pr-preview.md
@@ -17,7 +17,7 @@ This depends on the following actions:
 
 **Optional** The type of runner to use for the job
 
-**Default** `self-hosted`
+**Default** `k8s-linux`
 
 ### `base-url`
 

--- a/docs/web-cd.md
+++ b/docs/web-cd.md
@@ -13,7 +13,7 @@ This depends on the following workflows:
 
 **Optional** The type of runner to use for the job
 
-**Default** `self-hosted`
+**Default** `k8s-linux`
 
 ## Usage
 
@@ -29,7 +29,7 @@ jobs:
   deploy:
     uses: oncoursesystems/workflows/.github/workflows/web-cd.yml@main
     with:
-      runs-on: self-hosted
+      runs-on: k8s-linux
 ```
 
 This will:

--- a/docs/web-ci.md
+++ b/docs/web-ci.md
@@ -16,7 +16,7 @@ This depends on the following actions:
 
 **Optional** The type of runner to use for the job
 
-**Default** `self-hosted`
+**Default** `k8s-linux`
 
 ### `sparse-checkout`
 

--- a/docs/web-ci.md
+++ b/docs/web-ci.md
@@ -14,9 +14,15 @@ This depends on the following actions:
 
 ### `runs-on`
 
-**Optional** The type of runner to use for the job
+**Optional** The type of runner to use for the Node.js and .NET Core build jobs
 
 **Default** `k8s-linux`
+
+### `runs-on-windows`
+
+**Optional** The type of runner to use for the .NET Framework build job (requires Windows/MSBuild)
+
+**Default** `self-hosted`
 
 ### `sparse-checkout`
 

--- a/examples/web/pr-preview.yml
+++ b/examples/web/pr-preview.yml
@@ -8,7 +8,7 @@ jobs:
   manage-preview-environment:
     uses: oncoursesystems/workflows/.github/workflows/pr-preview.yml@main
     with:
-      runs-on: linux
+      runs-on: k8s-linux
       base-url: yourdomain.com
       environments: "['devel']"
       env-values-path: ./github/examples/errata/pr-previews


### PR DESCRIPTION
## Summary
- Default runner changed from `self-hosted` to `k8s-linux` across all reusable workflows (`create-release`, `docker-build`, `docker-cleanup`, `web-cd`, `web-ci`)
- `pr-preview-notify` now accepts a `runs-on` input (default `k8s-linux`) instead of being hardcoded
- `web-ci` gets a new `runs-on-windows` input (default `self-hosted`) for the .NET Framework build job, since MSBuild requires Windows
- All docs and examples updated to reflect the new defaults

## Test plan
- [ ] Verify a repo using `web-ci` with .NET Framework still builds on the `self-hosted` Windows runner
- [ ] Verify a repo using `web-ci` with only .NET Core builds successfully on `k8s-linux`
- [ ] Verify `docker-build`, `docker-cleanup`, `create-release`, `web-cd` work on `k8s-linux`
- [ ] Verify `pr-preview-notify` works with the new input-based runner selection