### PR TITLE
chore: upgrade all GitHub Actions to node24 runtime

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: ⬇️ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate version number - Windows OS
         if: ${{ runner.os == 'Windows' }}
@@ -34,7 +34,7 @@ jobs:
           echo "VERSION=$(date +"%Y.%m.%d.%H%M")" >> ${GITHUB_ENV}
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           token: ${{ secrets.CREATE_RELEASE_PAT }}
           name: v${{ env.VERSION }}

--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -18,7 +18,7 @@ jobs:
       # indexes — it treats per-platform manifests as "untagged" and deletes
       # them, breaking the tagged index. This action is OCI-index-aware.
       - name: Delete untagged packages
-        uses: dataaxiom/ghcr-cleanup-action@v1
+        uses: dataaxiom/ghcr-cleanup-action@v1.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           package: ${{ inputs.package-name }}

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -69,10 +69,10 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -531,7 +531,7 @@ jobs:
 
       - name: Upload Screenshots
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: agentic-ui-tests-screenshots
           path: |
@@ -542,7 +542,7 @@ jobs:
 
       - name: Upload Test Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: agentic-ui-tests-report
           path: test-results.json

--- a/.github/workflows/pr-preview-notify.yml
+++ b/.github/workflows/pr-preview-notify.yml
@@ -34,13 +34,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Post "Deploying" comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -90,7 +90,7 @@ jobs:
 
       - name: Post "Ready" comment
         if: steps.poll.outputs.outcome == 'healthy'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -112,7 +112,7 @@ jobs:
 
       - name: Post "Timeout" comment
         if: steps.poll.outputs.outcome == 'timeout'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: ⬇️ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: ${{ inputs.sparse-checkout }}
 
@@ -70,7 +70,7 @@ jobs:
       - name: 🏦 Cache dependencies
         if: steps.test.outputs.files_exists == 'true'
         id: cache-bun
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
@@ -91,7 +91,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: ⬇️ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: ${{ inputs.sparse-checkout }}
 
@@ -104,7 +104,7 @@ jobs:
 
       - name: ⚙️ Setup Dotnet
         if: steps.test.outputs.files_exists == 'true'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
           cache: true
@@ -124,7 +124,7 @@ jobs:
     runs-on: ${{ inputs.runs-on-windows }}
     steps:
       - name: ⬇️ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: ${{ inputs.sparse-checkout }}
 
@@ -137,7 +137,7 @@ jobs:
 
       - name: ⚙️ Setup MSBuild
         if: steps.test.outputs.files_exists == 'true'
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: ⚙️ Setup Nuget
         if: steps.test.outputs.files_exists == 'true'

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: ⚙️ Setup Nuget
         if: steps.test.outputs.files_exists == 'true'
-        uses: nuget/setup-nuget@v2
+        uses: nuget/setup-nuget@v4
 
       - name: 📦 Restore packages
         if: steps.test.outputs.files_exists == 'true'


### PR DESCRIPTION
## Summary
- Upgrade all GitHub Actions from node20 to node24 to resolve deprecation warnings
- GitHub skipped node22 entirely; the migration path is node20 → node24
- All runners need to be v2.327.1+ (v2.329.0+ for checkout@v6)

## Actions Upgraded

| Action | Old | New | Workflow(s) |
|--------|-----|-----|-------------|
| `actions/checkout` | v4 | **v6** | web-ci, e2e-testing, create-release, pr-review |
| `actions/cache` | v4 | **v5** | web-ci |
| `actions/setup-dotnet` | v4 | **v5** | web-ci |
| `actions/setup-node` | v4 | **v6** | e2e-testing |
| `actions/upload-artifact` | v4 | **v7** | e2e-testing |
| `actions/github-script` | v7 | **v9** | pr-preview-notify |
| `actions/create-github-app-token` | v1 | **v3** | pr-preview-notify |
| `microsoft/setup-msbuild` | v2 | **v3** | web-ci |
| `nuget/setup-nuget` | v2 | **v4** | web-ci |
| `softprops/action-gh-release` | v2 | **v3** | create-release |
| `dataaxiom/ghcr-cleanup-action` | v1 | **v1.1.0** | docker-cleanup |

## Breaking Changes Verified
- **github-script@v9**: All inline scripts use the injected `github` object directly — no `require()` or `getOctokit` redeclaration
- **create-github-app-token@v3**: Inputs already use kebab-case (`app-id`, `private-key`)
- **checkout@v6**: Credentials now stored in `$RUNNER_TEMP` instead of local git config (no workflows depend on post-checkout git credentials)

## Test plan
- [ ] Verify CI runners are v2.329.0+
- [ ] Trigger web-ci workflow (dotnet core + framework + nodejs builds)
- [ ] Trigger a PR preview deployment to test pr-preview-notify
- [ ] Trigger a release to test create-release + docker-build
- [ ] Verify docker-cleanup still correctly handles multi-platform OCI indexes