### PR TITLE
fix: anchor bun lockfile hashFiles to fix cache key timeout

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+          key: ${{ runner.os }}-bun-${{ hashFiles(format('{0}/bun.lock', inputs.nodejs-project-path)) }}
           restore-keys: |
             ${{ runner.os }}-bun-
 


### PR DESCRIPTION
## Problem

`build-nodejs` jobs that use this reusable workflow are failing in the **Post 🏦 Cache dependencies** step with:

\`\`\`
The template is not valid. oncoursesystems/workflows/.github/workflows/web-ci.yml@main
(Line: 76, Col: 16): hashFiles('**/bun.lockb') couldn't finish within 120 seconds.
\`\`\`

(Seen on [oncourse-connect#581 CI run](https://github.com/oncoursesystems/oncourse-connect/actions/runs/26661360039/job/78584409199). The build itself succeeds — only the cache step fails.)

## Root cause

The cache key was `hashFiles('**/bun.lockb')`, which has two distinct bugs:

1. **Wrong filename.** Consumer repos now ship the JSON text lockfile `bun.lock` (the default since Bun 1.2), not the legacy binary `bun.lockb`. The glob matched nothing, so the cache key was effectively static — defeating dependency caching.
2. **Recursive glob + node_modules.** `actions/cache` re-evaluates the `key` expression at save time (post step). By then `node_modules` is fully populated, and the `**/` recursive walk over that tree exceeds `hashFiles`' hard **120-second** limit — failing the whole job. (The timeout fired ~120s after the build finished, confirming the post-step re-evaluation.)

## Fix

Anchor the pattern to the configured `nodejs-project-path` input so `hashFiles` stats a single known file instead of recursing through `node_modules`:

\`\`\`yaml
key: ${{ runner.os }}-bun-${{ hashFiles(format('{0}/bun.lock', inputs.nodejs-project-path)) }}
\`\`\`

This fixes both the filename and the timeout, and restores real dependency caching. `nodejs-project-path` defaults to `.`, so repos that don't set it resolve to `./bun.lock`.