### PR TITLE
Add optional build-args input to docker-build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -43,6 +43,11 @@ on:
         type: string
         required: false
         default: linux/amd64
+      build-args:
+        description: Extra newline-delimited build args appended to APP_VERSION (e.g. "FOO=bar")
+        type: string
+        required: false
+        default: ''
       tag-rules:
         description: Defines rules for creating tags
         type: string
@@ -109,6 +114,7 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           build-args: |
             APP_VERSION=${{ steps.metadata.outputs.version }}
+            ${{ inputs.build-args }}
           cache-from: type=registry,ref=${{ inputs.registry }}/${{ inputs.image-name }}:buildcache
           cache-to: type=registry,ref=${{ inputs.registry }}/${{ inputs.image-name }}:buildcache,mode=max
 


### PR DESCRIPTION
## Why
The reusable `docker-build.yml` hardcoded `build-args: APP_VERSION=${{ steps.metadata.outputs.version }}`, so callers had no way to pass additional Docker build args.

## What
Add an optional `build-args` input (newline-delimited string, default empty), appended after `APP_VERSION`:

```yaml
build-args: |
  APP_VERSION=${{ steps.metadata.outputs.version }}
  ${{ inputs.build-args }}
```

Backwards compatible — callers that don't set it are unaffected.

## Used by
`oncoursesystems/oncourse-connect#634` passes `VITE_ASSET_HOST=https://assets.oncourseconnect.com` so the production image references the R2-backed asset CDN. Merge alongside that PR.